### PR TITLE
Use local instead of session storage to store cookies consent

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -20,13 +20,13 @@ document.addEventListener('DOMContentLoaded', function () {
     cookiesBannerJs(
         function() {
             try {
-                return JSON.parse(sessionStorage.getItem('consent_preferences'));
+                return JSON.parse(localStorage.getItem('consent_preferences'));
             } catch (error) {
                 return null;
             }
         },
         function(consentState) {
-            sessionStorage.setItem('consent_preferences', JSON.stringify(consentState));
+            localStorage.setItem('consent_preferences', JSON.stringify(consentState));
             const isGranted = consentState['ga_storage'];
             if (isGranted === "granted") {
                 window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
Drobna poprawka w logice, przy session storage zgoda znika razem z zamknięciem karty, local storage sprawdzi się tutaj lepiej bo nie ma daty wygaśnięcia. 